### PR TITLE
Fix for enotes.com paywall

### DIFF
--- a/userscript/bpc.en.user.js
+++ b/userscript/bpc.en.user.js
@@ -1464,15 +1464,14 @@ else if (matchDomain('enotes.com')) {
   let paywall = document.querySelectorAll('section.c-cta-section');
   if (paywall.length) {
     removeDOMElement(...paywall);
-    let blurred = document.querySelectorAll('div[class^="_"]');
+    let blurred = document.querySelectorAll('div[class="u-paywall"]');
     for (let elem of blurred)
       elem.removeAttribute('class');
-    let intro = document.querySelectorAll('div.o-rte-text > p:not([class]), div.o-rte-text > h3');
+    let intro = document.querySelectorAll('div.o-rte-text > div:not([class])');
     for (let elem of intro)
       removeDOMElement(elem);
-    let section_words = pageContains('p[class="u-align--center"]', /\(The entire section contains/);
-    let ads = document.querySelectorAll('.ad-hfu');
-    hideDOMElement(...section_words, ...ads);
+    let section_words = document.querySelectorAll('p.u-align--center');
+    hideDOMElement(...section_words);
   }
 }
 


### PR DESCRIPTION
Potential fix for #3.

Updated the en script to check for the correct paywall class, is able to remove the paywalls for me. Restored page content. h3 paragraphs are being used for legitimate section headers so no longer needs to be removed from DOM. Cleaned up lingering divs that can remain between paragraphs(ad placeholders)